### PR TITLE
chore(demo): reintroduce self-healing pipeline errors

### DIFF
--- a/dbt/models/staging/stg_orders.sql
+++ b/dbt/models/staging/stg_orders.sql
@@ -7,12 +7,12 @@ staged as (
     select
         order_id,
         customer_id,
-        cast(order_date as date) as order_date,
+        cast(ordered_at as date) as order_date,
         product_name,
         quantity,
         unit_price,
         quantity * unit_price as line_total,
-        status,
+        upper(status) as status,
         current_timestamp as loaded_at
     from source
 )


### PR DESCRIPTION
## Summary
Reintroduces two intentional errors in dbt/models/staging/stg_orders.sql for self-healing pipeline demonstrations.

## Intentional changes
- cast(order_date as date) -> cast(ordered_at as date) to trigger a schema/compile error.
- status -> upper(status) as status to trigger downstream data-quality failure after the first fix.

## Notes
- This PR is for demo/testing the agentic self-healing flow.
- Not intended for production merge without explicit approval.